### PR TITLE
Allow scope values to contain ":"

### DIFF
--- a/src/hiera_explorer/core.clj
+++ b/src/hiera_explorer/core.clj
@@ -60,7 +60,7 @@
                  (f/text-field {:class "form-control"} name value)
                  (when (yaml/dirty? value)
                    [:span.help-block
-                    "Only the following characters are allowd: a-z A-Z 0-9 _ -"])]])
+                    "Only the following characters are allowd: a-z A-Z 0-9 : . _ -"])]])
              [:div.form-group
               [:div.col-md-offset-2.col-md-10
                (f/submit-button {:class "btn btn-primary"} "Submit")]]))

--- a/src/hiera_explorer/yaml.clj
+++ b/src/hiera_explorer/yaml.clj
@@ -15,7 +15,7 @@
    (config (keyword ":hierarchy"))))
 
 (defn dirty? [string]
-  (not (re-seq #"^[a-zA-Z0-9._-]*$" string)))
+  (not (re-seq #"^[a-zA-Z0-9:._-]*$" string)))
 
 (defn expand-variables [string value-map]
   "Replaces patterns of the form %{variable-name} with values from the a map


### PR DESCRIPTION
Things like puppet class names can be in there, and those can legitimately contain `:`
